### PR TITLE
Add ostrio:cron-jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The official Meteor resources page can be found [here](https://www.meteor.com/to
 
 * [percolate:synced-cron](https://github.com/percolatestudio/meteor-synced-cron) - Cron system for Meteor. It supports syncronizing jobs between multiple processes.
 * [vsivsi:job-collection](https://github.com/vsivsi/meteor-job-collection/) - A persistent and reactive job queue for Meteor, supporting distributed workers that can run anywhere.
+* [ostrio:cron-jobs](https://github.com/VeliovGroup/Meteor-CRON-jobs) - Package with similar API to native `setTimeout` and `setInterval` methods, but synced between all running Meteor (NodeJS) instances.
 
 ## Debugging Tools
 


### PR DESCRIPTION
Package with similar API to native `setTimeout` and `setInterval` methods, but synced between all running Meteor (NodeJS) instances. [`ostrio:cron-jobs`](https://github.com/VeliovGroup/Meteor-CRON-jobs)